### PR TITLE
parse-url 1.3.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ If you are using this library in one of your projects, add it in this list. :spa
  - [`deploy-versioning`](https://npmjs.com/package/deploy-versioning)—Deploy your code keeping older versions.
  - [`git-up`](https://github.com/IonicaBizau/git-up)—A low level git url parser.
  - [`hubot-will-it-connect`](https://github.com/gambtho/hubot-will-it-connect#readme) (by gambtho)—Connects hubot with willitconnect, to validate CF's ability to connect to external resources
- - [`kakapo`](https://github.com/devlucky/Kakapo.js#readme) (by devlucky)—Next generation mocking library in Javascript
+ - [`kakapo`](https://github.com/devlucky/Kakapo.js#readme) (by devlucky)—Next generation mocking framework in Javascript
  - [`lien`](https://github.com/LienJS/Lien)—Another lightweight NodeJS framework. Lien is the link between request and response objects.
  - [`microbe.js`](https://github.com/Aweary/microbe.js) (by Brandon Dail)—A small Node.js framework for simple routing
  - [`tumblr-text`](https://npmjs.com/package/tumblr-text) (by cobaimelan)—[![Build Status](http://img.shields.io/travis/ayhankuru/tumblr-text.svg?style=flat-square)](https://travis-ci.org/ayhankuru/tumblr-text) [![Build Status](https://img.shields.io/david/ayhankuru/tumblr-text.svg?style=flat-square)](https://david-dm.org/ayhan

--- a/lib/index.js
+++ b/lib/index.js
@@ -41,7 +41,13 @@ function parseUrl(url) {
       ;
 
 
-    output.protocol = output.protocols[0] || (isSsh(url) ? "ssh" : "file");
+    output.protocol = output.protocols[0] || (
+        isSsh(url)
+            ? "ssh"
+            : url.charAt(1) === "/"
+                ? ((url = url.substring(2)) && "")
+                : "file"
+    );
 
     if (protocolIndex !== -1) {
         url = url.substring(protocolIndex + 3);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parse-url",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "An advanced url parser supporting git urls too.",
   "main": "lib/index.js",
   "directories": {

--- a/test/index.js
+++ b/test/index.js
@@ -18,6 +18,19 @@ const INPUTS = [
         }
     ]
   , [
+        "//ionicabizau.net/foo.js"
+      , {
+            protocols: []
+          , protocol: ""
+          , port: null
+          , resource: "ionicabizau.net"
+          , user: ""
+          , pathname: "/foo.js"
+          , hash: ""
+          , search: ""
+        }
+    ]
+  , [
         "http://domain.com/path/name?foo=bar&bar=42#some-hash"
       , {
             protocols: ["http"]


### PR DESCRIPTION
Handle no-protocol links.

When the urls starts with // then that is NOT a local path but a remote one, without a protocol.