### PR TITLE
Downgrade the version of normalize-url

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parse-url",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "description": "An advanced url parser supporting git urls too.",
   "main": "lib/index.js",
   "directories": {
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "is-ssh": "^1.3.0",
-    "normalize-url": "^6.0.1",
+    "normalize-url": "4.5.0",
     "parse-path": "^4.0.0",
     "protocols": "^1.4.0"
   },


### PR DESCRIPTION
Version ^6.0.1 of normalize-url does not work with Safari (because of incompatible regex - a negative lookbehind, which Safari can't handle).
Your package is an indirect dependency in one of our dependencies, so, unfortunately, we can't pin its version.
I have checked the normalize-url code and it looks like v4.5.0 doesn't have the incompatable regex (it's commented out).

closes #22