### PR TITLE
parse-url 6.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,22 +292,22 @@ If you are using this library in one of your projects, add it in this list. :spa
  - `cli-live-tutorial`
  - `@buganto/client`
  - `@datalogic/react-native-datalogic-module`
- - `@ndla/source-map-resolver`
  - `birken-react-native-community-image-editor`
  - `native-kakao-login`
  - `react-native-modal-progress-bar`
- - `cv-app-payment-adyen`
- - `react-native-flyy`
- - `react-native-dsphoto-module`
  - `@hawkingnetwork/react-native-tab-view`
  - `miguelcostero-ng2-toasty`
  - `vue-cli-plugin-ut-builder`
+ - `cv-app-payment-adyen`
+ - `react-native-flyy`
  - `drowl-base-theme-iconset`
  - `gitlab-backup-util-harduino`
  - `loast`
  - `rn-custom-tabview`
  - `homebridge-pushcutter`
  - `soajs.repositories`
+ - `@ntt_app/react-native-custom-notification`
+ - `@ndla/source-map-resolver`
 
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parse-url",
-  "version": "5.0.6",
+  "version": "6.0.0",
   "description": "An advanced url parser supporting git urls too.",
   "main": "lib/index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "is-ssh": "^1.3.0",
-    "normalize-url": "4.5.0",
+    "normalize-url": "^6.1.0",
     "parse-path": "^4.0.0",
     "protocols": "^1.4.0"
   },


### PR DESCRIPTION
Major release to update normalize-url to the latest version.

**Perhaps not compatible with Safari anymore unless normalize-url will release a patch.**

Fixes #19. :tada: