### PR TITLE
parse-url 6.0.0

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -10,7 +10,7 @@ Parses the input url.
 #### Params
 
 - **String** `url`: The input url.
-- **Boolean|Object** `normalize`: Wheter to normalize the url or not.                         Default is `false`. If `true`, the url will
+- **Boolean|Object** `normalize`: Whether to normalize the url or not.                         Default is `false`. If `true`, the url will
                         be normalized. If an object, it will be the
                         options object sent to [`normalize-url`](https://github.com/sindresorhus/normalize-url).
 
@@ -18,14 +18,14 @@ Parses the input url.
 
 #### Return
 - **Object** An object containing the following fields:
- - `protocols` (Array): An array with the url protocols (usually it has one element).
- - `protocol` (String): The first protocol, `"ssh"` (if the url is a ssh url) or `"file"`.
- - `port` (null|Number): The domain port.
- - `resource` (String): The url domain (including subdomains).
- - `user` (String): The authentication user (usually for ssh urls).
- - `pathname` (String): The url pathname.
- - `hash` (String): The url hash.
- - `search` (String): The url querystring value.
- - `href` (String): The input url.
- - `query` (Object): The url querystring, parsed as object.
+   - `protocols` (Array): An array with the url protocols (usually it has one element).
+   - `protocol` (String): The first protocol, `"ssh"` (if the url is a ssh url) or `"file"`.
+   - `port` (null|Number): The domain port.
+   - `resource` (String): The url domain (including subdomains).
+   - `user` (String): The authentication user (usually for ssh urls).
+   - `pathname` (String): The url pathname.
+   - `hash` (String): The url hash.
+   - `search` (String): The url querystring value.
+   - `href` (String): The input url.
+   - `query` (Object): The url querystring, parsed as object.
 

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Parses the input url.
 #### Params
 
 - **String** `url`: The input url.
-- **Boolean|Object** `normalize`: Wheter to normalize the url or not.                         Default is `false`. If `true`, the url will
+- **Boolean|Object** `normalize`: Whether to normalize the url or not.                         Default is `false`. If `true`, the url will
                         be normalized. If an object, it will be the
                         options object sent to [`normalize-url`](https://github.com/sindresorhus/normalize-url).
 
@@ -168,16 +168,16 @@ Parses the input url.
 
 #### Return
 - **Object** An object containing the following fields:
- - `protocols` (Array): An array with the url protocols (usually it has one element).
- - `protocol` (String): The first protocol, `"ssh"` (if the url is a ssh url) or `"file"`.
- - `port` (null|Number): The domain port.
- - `resource` (String): The url domain (including subdomains).
- - `user` (String): The authentication user (usually for ssh urls).
- - `pathname` (String): The url pathname.
- - `hash` (String): The url hash.
- - `search` (String): The url querystring value.
- - `href` (String): The input url.
- - `query` (Object): The url querystring, parsed as object.
+   - `protocols` (Array): An array with the url protocols (usually it has one element).
+   - `protocol` (String): The first protocol, `"ssh"` (if the url is a ssh url) or `"file"`.
+   - `port` (null|Number): The domain port.
+   - `resource` (String): The url domain (including subdomains).
+   - `user` (String): The authentication user (usually for ssh urls).
+   - `pathname` (String): The url pathname.
+   - `hash` (String): The url hash.
+   - `search` (String): The url querystring value.
+   - `href` (String): The input url.
+   - `query` (Object): The url querystring, parsed as object.
 
 
 
@@ -254,44 +254,43 @@ If you are using this library in one of your projects, add it in this list. :spa
  - `@hemith/react-native-tnk`
  - `@kriblet/wa-automate`
  - `@notnuzzel/crawl`
- - `native-kakao-login`
- - `begg`
  - `gitlab-backup-util-harduino`
- - `miguelcostero-ng2-toasty`
- - `npm_one_1_2_3`
  - `bilibili2local`
- - `react-native-arunmeena1987`
- - `react-native-biometric-authenticate`
- - `react-native-contact-list`
- - `react-native-is7`
- - `react-native-payu-payment-testing`
- - `react-native-kakao-maps`
+ - `miguelcostero-ng2-toasty`
+ - `native-kakao-login`
  - `react-native-my-first-try-arun-ramya`
+ - `react-native-kakao-maps`
+ - `react-native-is7`
  - `react-native-ytximkit`
+ - `react-native-payu-payment-testing`
+ - `npm_one_1_2_3`
+ - `react-native-biometric-authenticate`
+ - `react-native-arunmeena1987`
+ - `react-native-contact-list`
  - `rn-adyen-dropin`
- - `@dataparty/api`
- - `@datalogic/react-native-datalogic-module`
+ - `@positionex/position-sdk`
+ - `begg`
  - `@corelmax/react-native-my2c2p-sdk`
+ - `@dataparty/api`
  - `@felipesimmi/react-native-datalogic-module`
- - `@hawkingnetwork/react-native-tab-view`
  - `@jprustv/sulla-hotfix`
+ - `@hawkingnetwork/react-native-tab-view`
  - `@mergulhao/wa-automate`
+ - `cli-live-tutorial`
+ - `drowl-base-theme-iconset`
+ - `native-apple-login`
  - `react-native-cplus`
  - `npm_qwerty`
- - `native-apple-login`
- - `drowl-base-theme-iconset`
- - `cli-live-tutorial`
- - `react-native-arunjeyam1987`
- - `verify-aws-sns-signature`
- - `vue-cli-plugin-ice-builder`
- - `vrt-cli`
  - `ssh-host-manager`
  - `soajs.repositories`
+ - `react-native-arunjeyam1987`
  - `react-native-bubble-chart`
+ - `verify-aws-sns-signature`
+ - `vrt-cli`
+ - `vue-cli-plugin-ice-builder`
  - `react-native-flyy`
- - `native-zip`
  - `graphmilker`
- - `tumblr-text`
+ - `native-zip`
  - `@apardellass/react-native-audio-stream`
  - `@geeky-apo/react-native-advanced-clipboard`
  - `@hsui/plugin-wss`
@@ -300,22 +299,22 @@ If you are using this library in one of your projects, add it in this list. :spa
  - `@roshub/api`
  - `@saad27/react-native-bottom-tab-tour`
  - `generator-bootstrap-boilerplate-template`
- - `homebridge-pushcutter`
  - `react-feedback-sdk`
  - `loast`
  - `npm_one_12_34_1_`
  - `npm_one_2_2`
- - `react-native-responsive-size`
+ - `payutesting`
  - `react-native-sayhello-module`
  - `react-native-dsphoto-module`
- - `payutesting`
  - `vue-cli-plugin-ut-builder`
  - `xbuilder-forms`
+ - `tumblr-text`
  - `deploy-versioning`
  - `eval-spider`
+ - `homebridge-pushcutter`
+ - `@con-test/react-native-concent-common`
  - `@hstech/utils`
  - `@angga30prabu/wa-modified`
- - `@lakutata-module/service`
  - `birken-react-native-community-image-editor`
  - `get-tarball-cli`
  - `luojia-cli-dev`
@@ -325,33 +324,36 @@ If you are using this library in one of your projects, add it in this list. :spa
  - `react-native-arun-ramya-test`
  - `react-native-arunramya151`
  - `react-native-plugpag-wrapper`
- - `delta-screen`
  - `workpad`
- - `microbe.js`
  - `ndla-source-map-resolver`
  - `@screeb/react-native`
+ - `@lakutata-module/service`
+ - `delta-screen`
+ - `microbe.js`
+ - `@buganto/client`
+ - `@jimengio/mocked-proxy`
  - `@mockswitch/cli`
  - `@ndla/source-map-resolver`
- - `@jimengio/mocked-proxy`
- - `@buganto/client`
- - `ts-scraper`
- - `ba-js-cookie-banner`
+ - `angularvezba`
+ - `api-reach-react-native-fix`
+ - `astra-ufo-sdk`
  - `react-native-syan-photo-picker`
  - `@wecraftapps/react-native-use-keyboard`
- - `angularvezba`
  - `hui-plugin-wss`
  - `l2forlerna`
  - `native-google-login`
+ - `raact-native-arunramya151`
  - `react-native-modal-progress-bar`
  - `react-native-test-module-hhh`
- - `raact-native-arunramya151`
+ - `react-native-jsi-device-info`
  - `react-native-badge-control`
  - `rn-tm-notify`
  - `wander-cli`
- - `hubot-will-it-connect`
- - `react-native-jsi-device-info`
+ - `ts-scraper`
  - `heroku-wp-environment-sync`
+ - `hubot-will-it-connect`
  - `normalize-ssh-url`
+ - `ba-js-cookie-banner`
 
 
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,9 @@
 "use strict"
 
+// Dependencies
 const parsePath = require("parse-path")
     , normalizeUrl = require("normalize-url")
+
 
 /**
  * parseUrl
@@ -12,7 +14,7 @@ const parsePath = require("parse-path")
  * @name parseUrl
  * @function
  * @param {String} url The input url.
- * @param {Boolean|Object} normalize Wheter to normalize the url or not.
+ * @param {Boolean|Object} normalize Whether to normalize the url or not.
  *                         Default is `false`. If `true`, the url will
  *                         be normalized. If an object, it will be the
  *                         options object sent to [`normalize-url`](https://github.com/sindresorhus/normalize-url).
@@ -21,21 +23,26 @@ const parsePath = require("parse-path")
  *
  * @return {Object} An object containing the following fields:
  *
- *  - `protocols` (Array): An array with the url protocols (usually it has one element).
- *  - `protocol` (String): The first protocol, `"ssh"` (if the url is a ssh url) or `"file"`.
- *  - `port` (null|Number): The domain port.
- *  - `resource` (String): The url domain (including subdomains).
- *  - `user` (String): The authentication user (usually for ssh urls).
- *  - `pathname` (String): The url pathname.
- *  - `hash` (String): The url hash.
- *  - `search` (String): The url querystring value.
- *  - `href` (String): The input url.
- *  - `query` (Object): The url querystring, parsed as object.
+ *    - `protocols` (Array): An array with the url protocols (usually it has one element).
+ *    - `protocol` (String): The first protocol, `"ssh"` (if the url is a ssh url) or `"file"`.
+ *    - `port` (null|Number): The domain port.
+ *    - `resource` (String): The url domain (including subdomains).
+ *    - `user` (String): The authentication user (usually for ssh urls).
+ *    - `pathname` (String): The url pathname.
+ *    - `hash` (String): The url hash.
+ *    - `search` (String): The url querystring value.
+ *    - `href` (String): The input url.
+ *    - `query` (Object): The url querystring, parsed as object.
  */
-function parseUrl(url, normalize = false) {
+const parseUrl = (url, normalize = false) => {
+
+    // Constants
+    const GIT_RE = /((git@|http(s)?:\/\/)([\w\.@]+)(\/|:))(([\~,\w,\-,\_,\/]+)(.git){0,1}((\/){0,1}))/
+
     if (typeof url !== "string" || !url.trim()) {
         throw new Error("Invalid url.")
     }
+
     if (normalize) {
         if (typeof normalize !== "object") {
             normalize = {
@@ -44,7 +51,21 @@ function parseUrl(url, normalize = false) {
         }
         url = normalizeUrl(url, normalize)
     }
+
     const parsed = parsePath(url)
+
+    // Potential git-ssh urls
+    if (parsed.protocol === "file") {
+        const matched  = parsed.href.match(GIT_RE)
+        if (matched) {
+            parsed.protocols = ["ssh"]
+            parsed.protocol = "ssh"
+            parsed.resource = matched[4]
+            parsed.user = "git"
+            parsed.pathname = `/${matched[6]}`
+        }
+    }
+
     return parsed;
 }
 

--- a/package.json
+++ b/package.json
@@ -31,10 +31,10 @@
     "tester": "^1.3.1"
   },
   "dependencies": {
-    "is-ssh": "^1.3.0",
+    "is-ssh": "^1.4.0",
     "normalize-url": "^6.1.0",
-    "parse-path": "^4.0.4",
-    "protocols": "^1.4.0"
+    "parse-path": "^5.0.0",
+    "protocols": "^2.0.1"
   },
   "files": [
     "bin/",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parse-url",
-  "version": "5.0.8",
+  "version": "6.0.0",
   "description": "An advanced url parser supporting git urls too.",
   "main": "lib/index.js",
   "directories": {

--- a/test/index.js
+++ b/test/index.js
@@ -2,7 +2,6 @@
 const parseUrl = require("../lib")
     , tester = require("tester")
     , normalizeUrl = require("normalize-url")
-    , qs = require("querystring")
     ;
 
 const INPUTS = [
@@ -11,12 +10,13 @@ const INPUTS = [
       , {
             protocols: [ "http" ]
           , protocol: "http"
-          , port: null
+          , port: ""
           , resource: "ionicabizau.net"
           , user: ""
           , pathname: "/blog"
           , hash: ""
           , search: ""
+          , query: {}
         }
     ]
   , [
@@ -24,12 +24,13 @@ const INPUTS = [
       , {
             protocols: ["http"]
           , protocol: "http"
-          , port: null
+          , port: ""
           , resource: "ionicabizau.net"
           , user: ""
           , pathname: "/foo.js"
           , hash: ""
           , search: ""
+          , query: {}
         }
     ]
   , [
@@ -37,12 +38,13 @@ const INPUTS = [
       , {
             protocols: ["http"]
           , protocol: "http"
-          , port: null
+          , port: ""
           , resource: "domain.com"
           , user: ""
           , pathname: "/path/name"
           , hash: "some-hash?foo=bar"
           , search: ""
+          , query: {}
         }
     ]
   , [
@@ -50,25 +52,27 @@ const INPUTS = [
       , {
             protocols: ["git", "ssh"]
           , protocol: "git"
-          , port: null
+          , port: ""
           , resource: "host.xz"
           , user: "git"
           , pathname: "/path/name.git"
           , hash: ""
           , search: ""
+          , query: {}
         }
     ]
   , [
         ["git@github.com:IonicaBizau/git-stats.git", false]
       , {
-            protocols: []
+            protocols: ["ssh"]
           , protocol: "ssh"
-          , port: null
+          , port: ""
           , resource: "github.com"
           , user: "git"
           , pathname: "/IonicaBizau/git-stats.git"
           , hash: ""
           , search: ""
+          , query: {}
         }
     ]
   , [
@@ -76,12 +80,13 @@ const INPUTS = [
       , {
             protocols: [ "http" ]
           , protocol: "http"
-          , port: null
+          , port: ""
           , resource: "ionicabizau.net"
           , user: ""
           , pathname: "/with-true-normalize"
           , hash: ""
           , search: ""
+          , query: {}
         }
     ]
 ];
@@ -91,13 +96,15 @@ tester.describe("check urls", test => {
         let url = Array.isArray(c[0]) ? c[0][0] : c[0]
         test.should("support " + url, () => {
             const res = parseUrl(url, c[0][1] !== false);
+
             if (c[0][1] !== false) {
                 url = normalizeUrl(url, {
                     stripHash: false
                 })
             }
-            c[1].query = qs.parse(c[1].search)
-            c[1].href = url
+
+            c[1].href = c[1].href || url
+            c[1].password = c[1].password || ""
             test.expect(res).toEqual(c[1]);
         });
     });


### PR DESCRIPTION
### `parse-url` 6.0.0

:star: This is a major release of `parse-url`! :star:

#### Breaking changes

 - If the input url has a trailing slash, the trailing slash will be added in the `pathname` too.
 - The `port` field is a string. By default empty.
 - Added the `password` field (default: `""`)
 - The resource may contain the `port` in it (e.g. `resource: "domain.com:4200"`).

#### Features

 - Faster
 - More secure
 - Cleaner codebase
