### PR TITLE
fix(types): Export with equal sign

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -15,4 +15,4 @@ declare interface ParsedUrl {
 
 declare function parseUrl(url: string, normalize?: boolean | Object): ParsedUrl;
 
-export default parseUrl
+export = parseUrl


### PR DESCRIPTION
This PR fixes the TypeScript export of `parseUrl()`. In the [source](https://github.com/IonicaBizau/parse-url/blob/64bedf6031ba3b74097997231c4aab462bc6b64f/lib/index.js#L74), the function is exported via `module.exports = parseUrl`, but the types state that the function is exported as `default`. Thus, when trying to import the library in TypeScript, I get the following error:

```
TypeError: (0 , parse_url_1.default) is not a function
```

With this fix, we can import the library like this:

```ts
import parseUrl = require('parse-url');
```

