### PR TITLE
feat: improve regex pattern

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -43,7 +43,7 @@ var normalizeUrl__default = /*#__PURE__*/_interopDefaultLegacy(normalizeUrl);
 const parseUrl = (url, normalize = false) => {
 
     // Constants
-    const GIT_RE = /(^(git@|http(s)?:\/\/)([\w\.\-@]+)(\/|:))(([\~,\.\w,\-,\_,\/]+)(.git){0,1}((\/){0,1}))/;
+    const GIT_RE = /^(?:git@|https?:\/\/)([\w\.\-@]+)[\/:]([\~,\.\w,\-,\_,\/]+?(?:\.git|\/)?)$/;
 
     const throwErr = msg => {
         const err = new Error(msg);
@@ -72,14 +72,15 @@ const parseUrl = (url, normalize = false) => {
 
     // Potential git-ssh urls
     if (parsed.parse_failed) {
-        const matched  = parsed.href.match(GIT_RE);
+        const matched = parsed.href.match(GIT_RE);
+
         if (matched) {
             parsed.protocols = ["ssh"];
             parsed.protocol = "ssh";
-            parsed.resource = matched[4];
-            parsed.host = matched[4];
+            parsed.resource = matched[1];
+            parsed.host = matched[1];
             parsed.user = "git";
-            parsed.pathname = `/${matched[6]}`;
+            parsed.pathname = `/${matched[2]}`;
             parsed.parse_failed = false;
         } else {
             throwErr("URL parsing failed.");

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -36,7 +36,7 @@ import normalizeUrl from 'normalize-url';
 const parseUrl = (url, normalize = false) => {
 
     // Constants
-    const GIT_RE = /(^(git@|http(s)?:\/\/)([\w\.\-@]+)(\/|:))(([\~,\.\w,\-,\_,\/]+)(.git){0,1}((\/){0,1}))/;
+    const GIT_RE = /^(?:git@|https?:\/\/)([\w\.\-@]+)[\/:]([\~,\.\w,\-,\_,\/]+?(?:\.git|\/)?)$/;
 
     const throwErr = msg => {
         const err = new Error(msg);
@@ -65,14 +65,15 @@ const parseUrl = (url, normalize = false) => {
 
     // Potential git-ssh urls
     if (parsed.parse_failed) {
-        const matched  = parsed.href.match(GIT_RE);
+        const matched = parsed.href.match(GIT_RE);
+
         if (matched) {
             parsed.protocols = ["ssh"];
             parsed.protocol = "ssh";
-            parsed.resource = matched[4];
-            parsed.host = matched[4];
+            parsed.resource = matched[1];
+            parsed.host = matched[1];
             parsed.user = "git";
-            parsed.pathname = `/${matched[6]}`;
+            parsed.pathname = `/${matched[2]}`;
             parsed.parse_failed = false;
         } else {
             throwErr("URL parsing failed.");

--- a/src/index.js
+++ b/src/index.js
@@ -35,7 +35,7 @@ import normalizeUrl from "normalize-url";
 const parseUrl = (url, normalize = false) => {
 
     // Constants
-    const GIT_RE = /(^(git@|http(s)?:\/\/)([\w\.\-@]+)(\/|:))(([\~,\.\w,\-,\_,\/]+)(.git){0,1}((\/){0,1}))/
+    const GIT_RE = /^(?:git@|https?:\/\/)([\w\.\-@]+)[\/:]([\~,\.\w,\-,\_,\/]+?(?:\.git|\/)?)$/
 
     const throwErr = msg => {
         const err = new Error(msg)
@@ -64,14 +64,15 @@ const parseUrl = (url, normalize = false) => {
 
     // Potential git-ssh urls
     if (parsed.parse_failed) {
-        const matched  = parsed.href.match(GIT_RE)
+        const matched = parsed.href.match(GIT_RE)
+
         if (matched) {
             parsed.protocols = ["ssh"]
             parsed.protocol = "ssh"
-            parsed.resource = matched[4]
-            parsed.host = matched[4]
+            parsed.resource = matched[1]
+            parsed.host = matched[1]
             parsed.user = "git"
-            parsed.pathname = `/${matched[6]}`
+            parsed.pathname = `/${matched[2]}`
             parsed.parse_failed = false
         } else {
             throwErr("URL parsing failed.")


### PR DESCRIPTION
## Problem
- Not bound at the end of the string, and the `^` start position was in a capture group
- Unnecessary capture groups and syntax (`{0,1}` instead of `?`) (`(\/|:)` instead of `[\:]`)
- `.git` should be escaped: `\.git`
- The ending pattern `(.git){0,1}((\/){0,1})` catches `.git/`, but it should be either `.git` or `/`: `(\.git|\/)?`

## Changes
Simplified and improved regular expression syntax by:
- Start and end bounds at each end of the pattern to match the full string
- Removed unnecessary capture groups
- Escaped `.`
- Mutually exclusive `.git|/`