### PR TITLE
feat: support custom SSH username

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -43,7 +43,7 @@ var normalizeUrl__default = /*#__PURE__*/_interopDefaultLegacy(normalizeUrl);
 const parseUrl = (url, normalize = false) => {
 
     // Constants
-    const GIT_RE = /^(?:git@|https?:\/\/)([\w\.\-@]+)[\/:]([\~,\.\w,\-,\_,\/]+?(?:\.git|\/)?)$/;
+    const GIT_RE = /^(?:([a-z_][a-z0-9_-]{0,31})@|https?:\/\/)([\w\.\-@]+)[\/:]([\~,\.\w,\-,\_,\/]+?(?:\.git|\/)?)$/;
 
     const throwErr = msg => {
         const err = new Error(msg);
@@ -77,10 +77,10 @@ const parseUrl = (url, normalize = false) => {
         if (matched) {
             parsed.protocols = ["ssh"];
             parsed.protocol = "ssh";
-            parsed.resource = matched[1];
-            parsed.host = matched[1];
-            parsed.user = "git";
-            parsed.pathname = `/${matched[2]}`;
+            parsed.resource = matched[2];
+            parsed.host = matched[2];
+            parsed.user = matched[1];
+            parsed.pathname = `/${matched[3]}`;
             parsed.parse_failed = false;
         } else {
             throwErr("URL parsing failed.");

--- a/dist/index.js
+++ b/dist/index.js
@@ -43,7 +43,7 @@ var normalizeUrl__default = /*#__PURE__*/_interopDefaultLegacy(normalizeUrl);
 const parseUrl = (url, normalize = false) => {
 
     // Constants
-    const GIT_RE = /(^(git@|http(s)?:\/\/)([\w\.\-@]+)(\/|:))(([\~,\.\w,\-,\_,\/]+)(.git){0,1}((\/){0,1}))/;
+    const GIT_RE = /^(?:git@|https?:\/\/)([\w\.\-@]+)[\/:]([\~,\.\w,\-,\_,\/]+?(?:\.git|\/)?)$/;
 
     const throwErr = msg => {
         const err = new Error(msg);
@@ -72,14 +72,15 @@ const parseUrl = (url, normalize = false) => {
 
     // Potential git-ssh urls
     if (parsed.parse_failed) {
-        const matched  = parsed.href.match(GIT_RE);
+        const matched = parsed.href.match(GIT_RE);
+
         if (matched) {
             parsed.protocols = ["ssh"];
             parsed.protocol = "ssh";
-            parsed.resource = matched[4];
-            parsed.host = matched[4];
+            parsed.resource = matched[1];
+            parsed.host = matched[1];
             parsed.user = "git";
-            parsed.pathname = `/${matched[6]}`;
+            parsed.pathname = `/${matched[2]}`;
             parsed.parse_failed = false;
         } else {
             throwErr("URL parsing failed.");

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -36,7 +36,7 @@ import normalizeUrl from 'normalize-url';
 const parseUrl = (url, normalize = false) => {
 
     // Constants
-    const GIT_RE = /^(?:git@|https?:\/\/)([\w\.\-@]+)[\/:]([\~,\.\w,\-,\_,\/]+?(?:\.git|\/)?)$/;
+    const GIT_RE = /^(?:([a-z_][a-z0-9_-]{0,31})@|https?:\/\/)([\w\.\-@]+)[\/:]([\~,\.\w,\-,\_,\/]+?(?:\.git|\/)?)$/;
 
     const throwErr = msg => {
         const err = new Error(msg);
@@ -70,10 +70,10 @@ const parseUrl = (url, normalize = false) => {
         if (matched) {
             parsed.protocols = ["ssh"];
             parsed.protocol = "ssh";
-            parsed.resource = matched[1];
-            parsed.host = matched[1];
-            parsed.user = "git";
-            parsed.pathname = `/${matched[2]}`;
+            parsed.resource = matched[2];
+            parsed.host = matched[2];
+            parsed.user = matched[1];
+            parsed.pathname = `/${matched[3]}`;
             parsed.parse_failed = false;
         } else {
             throwErr("URL parsing failed.");

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -36,7 +36,7 @@ import normalizeUrl from 'normalize-url';
 const parseUrl = (url, normalize = false) => {
 
     // Constants
-    const GIT_RE = /(^(git@|http(s)?:\/\/)([\w\.\-@]+)(\/|:))(([\~,\.\w,\-,\_,\/]+)(.git){0,1}((\/){0,1}))/;
+    const GIT_RE = /^(?:git@|https?:\/\/)([\w\.\-@]+)[\/:]([\~,\.\w,\-,\_,\/]+?(?:\.git|\/)?)$/;
 
     const throwErr = msg => {
         const err = new Error(msg);
@@ -65,14 +65,15 @@ const parseUrl = (url, normalize = false) => {
 
     // Potential git-ssh urls
     if (parsed.parse_failed) {
-        const matched  = parsed.href.match(GIT_RE);
+        const matched = parsed.href.match(GIT_RE);
+
         if (matched) {
             parsed.protocols = ["ssh"];
             parsed.protocol = "ssh";
-            parsed.resource = matched[4];
-            parsed.host = matched[4];
+            parsed.resource = matched[1];
+            parsed.host = matched[1];
             parsed.user = "git";
-            parsed.pathname = `/${matched[6]}`;
+            parsed.pathname = `/${matched[2]}`;
             parsed.parse_failed = false;
         } else {
             throwErr("URL parsing failed.");

--- a/src/index.js
+++ b/src/index.js
@@ -35,7 +35,7 @@ import normalizeUrl from "normalize-url";
 const parseUrl = (url, normalize = false) => {
 
     // Constants
-    const GIT_RE = /^(?:git@|https?:\/\/)([\w\.\-@]+)[\/:]([\~,\.\w,\-,\_,\/]+?(?:\.git|\/)?)$/
+    const GIT_RE = /^(?:([a-z_][a-z0-9_-]{0,31})@|https?:\/\/)([\w\.\-@]+)[\/:]([\~,\.\w,\-,\_,\/]+?(?:\.git|\/)?)$/
 
     const throwErr = msg => {
         const err = new Error(msg)
@@ -69,10 +69,10 @@ const parseUrl = (url, normalize = false) => {
         if (matched) {
             parsed.protocols = ["ssh"]
             parsed.protocol = "ssh"
-            parsed.resource = matched[1]
-            parsed.host = matched[1]
-            parsed.user = "git"
-            parsed.pathname = `/${matched[2]}`
+            parsed.resource = matched[2]
+            parsed.host = matched[2]
+            parsed.user = matched[1]
+            parsed.pathname = `/${matched[3]}`
             parsed.parse_failed = false
         } else {
             throwErr("URL parsing failed.")

--- a/src/index.js
+++ b/src/index.js
@@ -35,7 +35,7 @@ import normalizeUrl from "normalize-url";
 const parseUrl = (url, normalize = false) => {
 
     // Constants
-    const GIT_RE = /(^(git@|http(s)?:\/\/)([\w\.\-@]+)(\/|:))(([\~,\.\w,\-,\_,\/]+)(.git){0,1}((\/){0,1}))/
+    const GIT_RE = /^(?:git@|https?:\/\/)([\w\.\-@]+)[\/:]([\~,\.\w,\-,\_,\/]+?(?:\.git|\/)?)$/
 
     const throwErr = msg => {
         const err = new Error(msg)
@@ -64,14 +64,15 @@ const parseUrl = (url, normalize = false) => {
 
     // Potential git-ssh urls
     if (parsed.parse_failed) {
-        const matched  = parsed.href.match(GIT_RE)
+        const matched = parsed.href.match(GIT_RE)
+
         if (matched) {
             parsed.protocols = ["ssh"]
             parsed.protocol = "ssh"
-            parsed.resource = matched[4]
-            parsed.host = matched[4]
+            parsed.resource = matched[1]
+            parsed.host = matched[1]
             parsed.user = "git"
-            parsed.pathname = `/${matched[6]}`
+            parsed.pathname = `/${matched[2]}`
             parsed.parse_failed = false
         } else {
             throwErr("URL parsing failed.")

--- a/test/index.mjs
+++ b/test/index.mjs
@@ -134,6 +134,23 @@ const INPUTS = [
         }
     ]
   , [
+        ["org-12345678@github.my-enterprise.com:my-org/my-repo.git", false],
+        {
+            protocols: [ 'ssh' ]
+          , protocol: 'ssh'
+          , port: ''
+          , resource: 'github.my-enterprise.com'
+          , host: 'github.my-enterprise.com'
+          , user: 'org-12345678'
+          , password: ''
+          , pathname: '/my-org/my-repo.git'
+          , hash: ''
+          , search: ''
+          , query: {}
+          , parse_failed: false
+        }
+    ]
+  , [
       ["git@github.com:halup/Cloud.API.Gateway.git", false]
     , {
           protocols: [ "ssh" ]


### PR DESCRIPTION
Branched off from https://github.com/IonicaBizau/parse-url/pull/59

## Problem
GitHub Enterprise now uses a SSH username different from `git`. In my enterprise org, the SSH urls look like this:

```
org-42463807@github.com:squareup/repo-name.git
``` 

https://github.com/IonicaBizau/git-url-parse/issues/141

## Changes
Support custom SSH usernames. Pattern based on [this StackOverflow answer](https://unix.stackexchange.com/questions/157426/what-is-the-regex-to-validate-linux-users).
