### PR TITLE
Include index.d.ts in package

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "menu/",
     "cli.js",
     "index.js",
+    "index.d.ts",
     "bloggify.js",
     "bloggify.json",
     "bloggify/"


### PR DESCRIPTION
Fixes issue where v8.0.0 release does not include `index.d.ts` in the distributed package.