### PR TITLE
Update GIT_RE regex to match on SSH urls with spaces in Project/Repo Names

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -286,53 +286,55 @@ function normalizeUrl(urlString, options) {
  *    - `parse_failed` (Boolean): Whether the parsing failed or not.
  */
 const parseUrl = (url, normalize = false) => {
+  // Constants
+  // const GIT_RE = /^(?:([a-z_][a-z0-9_-]{0,31})@|https?:\/\/)([\w\.\-@]+)[\/:]([\~,\.\w,\-,\_,\/]+?(?:\.git|\/)?)$/
+  const GIT_RE =
+    /^(?:([a-z_][a-z0-9_-]{0,31})@|https?:\/\/)([\w\.\-@]+)[\/:](([\~,\.\w,\-,\_,\/,\s]|%[0-9A-Fa-f]{2})+?(?:\.git|\/)?)$/;
+  const throwErr = (msg) => {
+    const err = new Error(msg);
+    err.subject_url = url;
+    throw err;
+  };
 
-    // Constants
-    const GIT_RE = /^(?:([a-z_][a-z0-9_-]{0,31})@|https?:\/\/)([\w\.\-@]+)[\/:]([\~,\.\w,\-,\_,\/]+?(?:\.git|\/)?)$/;
+  if (typeof url !== "string" || !url.trim()) {
+    throwErr("Invalid url.");
+  }
 
-    const throwErr = msg => {
-        const err = new Error(msg);
-        err.subject_url = url;
-        throw err
-    };
+  if (url.length > parseUrl.MAX_INPUT_LENGTH) {
+    throwErr(
+      "Input exceeds maximum length. If needed, change the value of parseUrl.MAX_INPUT_LENGTH."
+    );
+  }
 
-    if (typeof url !== "string" || !url.trim()) {
-        throwErr("Invalid url.");
+  if (normalize) {
+    if (typeof normalize !== "object") {
+      normalize = {
+        stripHash: false,
+      };
     }
+    url = normalizeUrl(url, normalize);
+  }
 
-    if (url.length > parseUrl.MAX_INPUT_LENGTH) {
-        throwErr("Input exceeds maximum length. If needed, change the value of parseUrl.MAX_INPUT_LENGTH.");
+  const parsed = parsePath__default["default"](url);
+
+  // Potential git-ssh urls
+  if (parsed.parse_failed) {
+    const matched = parsed.href.match(GIT_RE);
+
+    if (matched) {
+      parsed.protocols = ["ssh"];
+      parsed.protocol = "ssh";
+      parsed.resource = matched[2];
+      parsed.host = matched[2];
+      parsed.user = matched[1];
+      parsed.pathname = `/${matched[3]}`;
+      parsed.parse_failed = false;
+    } else {
+      throwErr("URL parsing failed.");
     }
+  }
 
-    if (normalize) {
-        if (typeof normalize !== "object") {
-            normalize = {
-                stripHash: false
-            };
-        }
-        url = normalizeUrl(url, normalize);
-    }
-
-    const parsed = parsePath__default["default"](url);
-
-    // Potential git-ssh urls
-    if (parsed.parse_failed) {
-        const matched = parsed.href.match(GIT_RE);
-
-        if (matched) {
-            parsed.protocols = ["ssh"];
-            parsed.protocol = "ssh";
-            parsed.resource = matched[2];
-            parsed.host = matched[2];
-            parsed.user = matched[1];
-            parsed.pathname = `/${matched[3]}`;
-            parsed.parse_failed = false;
-        } else {
-            throwErr("URL parsing failed.");
-        }
-    }
-
-    return parsed;
+  return parsed;
 };
 
 parseUrl.MAX_INPUT_LENGTH = 2048;

--- a/dist/index.js
+++ b/dist/index.js
@@ -286,55 +286,52 @@ function normalizeUrl(urlString, options) {
  *    - `parse_failed` (Boolean): Whether the parsing failed or not.
  */
 const parseUrl = (url, normalize = false) => {
-  // Constants
-  // const GIT_RE = /^(?:([a-z_][a-z0-9_-]{0,31})@|https?:\/\/)([\w\.\-@]+)[\/:]([\~,\.\w,\-,\_,\/]+?(?:\.git|\/)?)$/
-  const GIT_RE =
-    /^(?:([a-z_][a-z0-9_-]{0,31})@|https?:\/\/)([\w\.\-@]+)[\/:](([\~,\.\w,\-,\_,\/,\s]|%[0-9A-Fa-f]{2})+?(?:\.git|\/)?)$/;
-  const throwErr = (msg) => {
-    const err = new Error(msg);
-    err.subject_url = url;
-    throw err;
-  };
 
-  if (typeof url !== "string" || !url.trim()) {
-    throwErr("Invalid url.");
-  }
+    // Constants
+    const GIT_RE = /^(?:([a-z_][a-z0-9_-]{0,31})@|https?:\/\/)([\w\.\-@]+)[\/:](([\~,\.\w,\-,\_,\/,\s]|%[0-9A-Fa-f]{2})+?(?:\.git|\/)?)$/;
+    const throwErr = msg => {
+        const err = new Error(msg);
+        err.subject_url = url;
+        throw err
+    };
 
-  if (url.length > parseUrl.MAX_INPUT_LENGTH) {
-    throwErr(
-      "Input exceeds maximum length. If needed, change the value of parseUrl.MAX_INPUT_LENGTH."
-    );
-  }
-
-  if (normalize) {
-    if (typeof normalize !== "object") {
-      normalize = {
-        stripHash: false,
-      };
+    if (typeof url !== "string" || !url.trim()) {
+        throwErr("Invalid url.");
     }
-    url = normalizeUrl(url, normalize);
-  }
 
-  const parsed = parsePath__default["default"](url);
-
-  // Potential git-ssh urls
-  if (parsed.parse_failed) {
-    const matched = parsed.href.match(GIT_RE);
-
-    if (matched) {
-      parsed.protocols = ["ssh"];
-      parsed.protocol = "ssh";
-      parsed.resource = matched[2];
-      parsed.host = matched[2];
-      parsed.user = matched[1];
-      parsed.pathname = `/${matched[3]}`;
-      parsed.parse_failed = false;
-    } else {
-      throwErr("URL parsing failed.");
+    if (url.length > parseUrl.MAX_INPUT_LENGTH) {
+        throwErr("Input exceeds maximum length. If needed, change the value of parseUrl.MAX_INPUT_LENGTH.");
     }
-  }
 
-  return parsed;
+    if (normalize) {
+        if (typeof normalize !== "object") {
+            normalize = {
+                stripHash: false
+            };
+        }
+        url = normalizeUrl(url, normalize);
+    }
+
+    const parsed = parsePath__default["default"](url);
+
+    // Potential git-ssh urls
+    if (parsed.parse_failed) {
+        const matched = parsed.href.match(GIT_RE);
+
+        if (matched) {
+            parsed.protocols = ["ssh"];
+            parsed.protocol = "ssh";
+            parsed.resource = matched[2];
+            parsed.host = matched[2];
+            parsed.user = matched[1];
+            parsed.pathname = `/${matched[3]}`;
+            parsed.parse_failed = false;
+        } else {
+            throwErr("URL parsing failed.");
+        }
+    }
+
+    return parsed;
 };
 
 parseUrl.MAX_INPUT_LENGTH = 2048;

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -280,55 +280,52 @@ function normalizeUrl(urlString, options) {
  *    - `parse_failed` (Boolean): Whether the parsing failed or not.
  */
 const parseUrl = (url, normalize = false) => {
-  // Constants
-  // const GIT_RE = /^(?:([a-z_][a-z0-9_-]{0,31})@|https?:\/\/)([\w\.\-@]+)[\/:]([\~,\.\w,\-,\_,\/]+?(?:\.git|\/)?)$/
-  const GIT_RE =
-    /^(?:([a-z_][a-z0-9_-]{0,31})@|https?:\/\/)([\w\.\-@]+)[\/:](([\~,\.\w,\-,\_,\/,\s]|%[0-9A-Fa-f]{2})+?(?:\.git|\/)?)$/;
-  const throwErr = (msg) => {
-    const err = new Error(msg);
-    err.subject_url = url;
-    throw err;
-  };
 
-  if (typeof url !== "string" || !url.trim()) {
-    throwErr("Invalid url.");
-  }
+    // Constants
+    const GIT_RE = /^(?:([a-z_][a-z0-9_-]{0,31})@|https?:\/\/)([\w\.\-@]+)[\/:](([\~,\.\w,\-,\_,\/,\s]|%[0-9A-Fa-f]{2})+?(?:\.git|\/)?)$/;
+    const throwErr = msg => {
+        const err = new Error(msg);
+        err.subject_url = url;
+        throw err
+    };
 
-  if (url.length > parseUrl.MAX_INPUT_LENGTH) {
-    throwErr(
-      "Input exceeds maximum length. If needed, change the value of parseUrl.MAX_INPUT_LENGTH."
-    );
-  }
-
-  if (normalize) {
-    if (typeof normalize !== "object") {
-      normalize = {
-        stripHash: false,
-      };
+    if (typeof url !== "string" || !url.trim()) {
+        throwErr("Invalid url.");
     }
-    url = normalizeUrl(url, normalize);
-  }
 
-  const parsed = parsePath(url);
-
-  // Potential git-ssh urls
-  if (parsed.parse_failed) {
-    const matched = parsed.href.match(GIT_RE);
-
-    if (matched) {
-      parsed.protocols = ["ssh"];
-      parsed.protocol = "ssh";
-      parsed.resource = matched[2];
-      parsed.host = matched[2];
-      parsed.user = matched[1];
-      parsed.pathname = `/${matched[3]}`;
-      parsed.parse_failed = false;
-    } else {
-      throwErr("URL parsing failed.");
+    if (url.length > parseUrl.MAX_INPUT_LENGTH) {
+        throwErr("Input exceeds maximum length. If needed, change the value of parseUrl.MAX_INPUT_LENGTH.");
     }
-  }
 
-  return parsed;
+    if (normalize) {
+        if (typeof normalize !== "object") {
+            normalize = {
+                stripHash: false
+            };
+        }
+        url = normalizeUrl(url, normalize);
+    }
+
+    const parsed = parsePath(url);
+
+    // Potential git-ssh urls
+    if (parsed.parse_failed) {
+        const matched = parsed.href.match(GIT_RE);
+
+        if (matched) {
+            parsed.protocols = ["ssh"];
+            parsed.protocol = "ssh";
+            parsed.resource = matched[2];
+            parsed.host = matched[2];
+            parsed.user = matched[1];
+            parsed.pathname = `/${matched[3]}`;
+            parsed.parse_failed = false;
+        } else {
+            throwErr("URL parsing failed.");
+        }
+    }
+
+    return parsed;
 };
 
 parseUrl.MAX_INPUT_LENGTH = 2048;

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -280,53 +280,55 @@ function normalizeUrl(urlString, options) {
  *    - `parse_failed` (Boolean): Whether the parsing failed or not.
  */
 const parseUrl = (url, normalize = false) => {
+  // Constants
+  // const GIT_RE = /^(?:([a-z_][a-z0-9_-]{0,31})@|https?:\/\/)([\w\.\-@]+)[\/:]([\~,\.\w,\-,\_,\/]+?(?:\.git|\/)?)$/
+  const GIT_RE =
+    /^(?:([a-z_][a-z0-9_-]{0,31})@|https?:\/\/)([\w\.\-@]+)[\/:](([\~,\.\w,\-,\_,\/,\s]|%[0-9A-Fa-f]{2})+?(?:\.git|\/)?)$/;
+  const throwErr = (msg) => {
+    const err = new Error(msg);
+    err.subject_url = url;
+    throw err;
+  };
 
-    // Constants
-    const GIT_RE = /^(?:([a-z_][a-z0-9_-]{0,31})@|https?:\/\/)([\w\.\-@]+)[\/:]([\~,\.\w,\-,\_,\/]+?(?:\.git|\/)?)$/;
+  if (typeof url !== "string" || !url.trim()) {
+    throwErr("Invalid url.");
+  }
 
-    const throwErr = msg => {
-        const err = new Error(msg);
-        err.subject_url = url;
-        throw err
-    };
+  if (url.length > parseUrl.MAX_INPUT_LENGTH) {
+    throwErr(
+      "Input exceeds maximum length. If needed, change the value of parseUrl.MAX_INPUT_LENGTH."
+    );
+  }
 
-    if (typeof url !== "string" || !url.trim()) {
-        throwErr("Invalid url.");
+  if (normalize) {
+    if (typeof normalize !== "object") {
+      normalize = {
+        stripHash: false,
+      };
     }
+    url = normalizeUrl(url, normalize);
+  }
 
-    if (url.length > parseUrl.MAX_INPUT_LENGTH) {
-        throwErr("Input exceeds maximum length. If needed, change the value of parseUrl.MAX_INPUT_LENGTH.");
+  const parsed = parsePath(url);
+
+  // Potential git-ssh urls
+  if (parsed.parse_failed) {
+    const matched = parsed.href.match(GIT_RE);
+
+    if (matched) {
+      parsed.protocols = ["ssh"];
+      parsed.protocol = "ssh";
+      parsed.resource = matched[2];
+      parsed.host = matched[2];
+      parsed.user = matched[1];
+      parsed.pathname = `/${matched[3]}`;
+      parsed.parse_failed = false;
+    } else {
+      throwErr("URL parsing failed.");
     }
+  }
 
-    if (normalize) {
-        if (typeof normalize !== "object") {
-            normalize = {
-                stripHash: false
-            };
-        }
-        url = normalizeUrl(url, normalize);
-    }
-
-    const parsed = parsePath(url);
-
-    // Potential git-ssh urls
-    if (parsed.parse_failed) {
-        const matched = parsed.href.match(GIT_RE);
-
-        if (matched) {
-            parsed.protocols = ["ssh"];
-            parsed.protocol = "ssh";
-            parsed.resource = matched[2];
-            parsed.host = matched[2];
-            parsed.user = matched[1];
-            parsed.pathname = `/${matched[3]}`;
-            parsed.parse_failed = false;
-        } else {
-            throwErr("URL parsing failed.");
-        }
-    }
-
-    return parsed;
+  return parsed;
 };
 
 parseUrl.MAX_INPUT_LENGTH = 2048;

--- a/package.json
+++ b/package.json
@@ -6,12 +6,14 @@
   "module": "./dist/index.mjs",
   "types": "./index.d.ts",
   "exports": {
-    "types": {
-      "require": "./index.d.ts",
-      "import": "./index.d.mts"
+    "require": {
+      "types": "./index.d.ts",
+      "default": "./dist/index.js"
     },
-    "require": "./dist/index.js",
-    "import": "./dist/index.mjs"
+    "import": {
+      "types": "./index.d.mts",
+      "default": "./dist/index.mjs"
+    }
   },
   "directories": {
     "example": "example",

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 // Dependencies
-import parsePath from "parse-path";
+
 import normalizeUrl from "normalize-url";
+import parsePath from "parse-path";
 
 /**
  * parseUrl
@@ -33,54 +34,56 @@ import normalizeUrl from "normalize-url";
  *    - `parse_failed` (Boolean): Whether the parsing failed or not.
  */
 const parseUrl = (url, normalize = false) => {
+  // Constants
+  // const GIT_RE = /^(?:([a-z_][a-z0-9_-]{0,31})@|https?:\/\/)([\w\.\-@]+)[\/:]([\~,\.\w,\-,\_,\/]+?(?:\.git|\/)?)$/
+  const GIT_RE =
+    /^(?:([a-z_][a-z0-9_-]{0,31})@|https?:\/\/)([\w\.\-@]+)[\/:](([\~,\.\w,\-,\_,\/,\s]|%[0-9A-Fa-f]{2})+?(?:\.git|\/)?)$/;
+  const throwErr = (msg) => {
+    const err = new Error(msg);
+    err.subject_url = url;
+    throw err;
+  };
 
-    // Constants
-    const GIT_RE = /^(?:([a-z_][a-z0-9_-]{0,31})@|https?:\/\/)([\w\.\-@]+)[\/:]([\~,\.\w,\-,\_,\/]+?(?:\.git|\/)?)$/
+  if (typeof url !== "string" || !url.trim()) {
+    throwErr("Invalid url.");
+  }
 
-    const throwErr = msg => {
-        const err = new Error(msg)
-        err.subject_url = url
-        throw err
+  if (url.length > parseUrl.MAX_INPUT_LENGTH) {
+    throwErr(
+      "Input exceeds maximum length. If needed, change the value of parseUrl.MAX_INPUT_LENGTH."
+    );
+  }
+
+  if (normalize) {
+    if (typeof normalize !== "object") {
+      normalize = {
+        stripHash: false,
+      };
     }
+    url = normalizeUrl(url, normalize);
+  }
 
-    if (typeof url !== "string" || !url.trim()) {
-        throwErr("Invalid url.")
+  const parsed = parsePath(url);
+
+  // Potential git-ssh urls
+  if (parsed.parse_failed) {
+    const matched = parsed.href.match(GIT_RE);
+
+    if (matched) {
+      parsed.protocols = ["ssh"];
+      parsed.protocol = "ssh";
+      parsed.resource = matched[2];
+      parsed.host = matched[2];
+      parsed.user = matched[1];
+      parsed.pathname = `/${matched[3]}`
+      parsed.parse_failed = false;
+    } else {
+      throwErr("URL parsing failed.");
     }
+  }
 
-    if (url.length > parseUrl.MAX_INPUT_LENGTH) {
-        throwErr("Input exceeds maximum length. If needed, change the value of parseUrl.MAX_INPUT_LENGTH.")
-    }
-
-    if (normalize) {
-        if (typeof normalize !== "object") {
-            normalize = {
-                stripHash: false
-            }
-        }
-        url = normalizeUrl(url, normalize)
-    }
-
-    const parsed = parsePath(url)
-
-    // Potential git-ssh urls
-    if (parsed.parse_failed) {
-        const matched = parsed.href.match(GIT_RE)
-
-        if (matched) {
-            parsed.protocols = ["ssh"]
-            parsed.protocol = "ssh"
-            parsed.resource = matched[2]
-            parsed.host = matched[2]
-            parsed.user = matched[1]
-            parsed.pathname = `/${matched[3]}`
-            parsed.parse_failed = false
-        } else {
-            throwErr("URL parsing failed.")
-        }
-    }
-
-    return parsed;
-}
+  return parsed;
+};
 
 parseUrl.MAX_INPUT_LENGTH = 2048
 

--- a/src/index.js
+++ b/src/index.js
@@ -36,7 +36,13 @@ import parsePath from "parse-path";
 const parseUrl = (url, normalize = false) => {
 
     // Constants
+    /**
+     * ([a-z_][a-z0-9_-]{0,31}) Try to match the user
+     * ([\w\.\-@]+) Match the host/resource
+     * (([\~,\.\w,\-,\_,\/,\s]|%[0-9A-Fa-f]{2})+?(?:\.git|\/)?) Match the path, allowing spaces/white 
+     */
     const GIT_RE = /^(?:([a-z_][a-z0-9_-]{0,31})@|https?:\/\/)([\w\.\-@]+)[\/:](([\~,\.\w,\-,\_,\/,\s]|%[0-9A-Fa-f]{2})+?(?:\.git|\/)?)$/;
+    
     const throwErr = msg => {
         const err = new Error(msg)
         err.subject_url = url

--- a/src/index.js
+++ b/src/index.js
@@ -34,56 +34,53 @@ import parsePath from "parse-path";
  *    - `parse_failed` (Boolean): Whether the parsing failed or not.
  */
 const parseUrl = (url, normalize = false) => {
-  // Constants
-  // const GIT_RE = /^(?:([a-z_][a-z0-9_-]{0,31})@|https?:\/\/)([\w\.\-@]+)[\/:]([\~,\.\w,\-,\_,\/]+?(?:\.git|\/)?)$/
-  const GIT_RE =
-    /^(?:([a-z_][a-z0-9_-]{0,31})@|https?:\/\/)([\w\.\-@]+)[\/:](([\~,\.\w,\-,\_,\/,\s]|%[0-9A-Fa-f]{2})+?(?:\.git|\/)?)$/;
-  const throwErr = (msg) => {
-    const err = new Error(msg);
-    err.subject_url = url;
-    throw err;
-  };
 
-  if (typeof url !== "string" || !url.trim()) {
-    throwErr("Invalid url.");
-  }
-
-  if (url.length > parseUrl.MAX_INPUT_LENGTH) {
-    throwErr(
-      "Input exceeds maximum length. If needed, change the value of parseUrl.MAX_INPUT_LENGTH."
-    );
-  }
-
-  if (normalize) {
-    if (typeof normalize !== "object") {
-      normalize = {
-        stripHash: false,
-      };
+    // Constants
+    const GIT_RE = /^(?:([a-z_][a-z0-9_-]{0,31})@|https?:\/\/)([\w\.\-@]+)[\/:](([\~,\.\w,\-,\_,\/,\s]|%[0-9A-Fa-f]{2})+?(?:\.git|\/)?)$/;
+    const throwErr = msg => {
+        const err = new Error(msg)
+        err.subject_url = url
+        throw err
     }
-    url = normalizeUrl(url, normalize);
-  }
 
-  const parsed = parsePath(url);
-
-  // Potential git-ssh urls
-  if (parsed.parse_failed) {
-    const matched = parsed.href.match(GIT_RE);
-
-    if (matched) {
-      parsed.protocols = ["ssh"];
-      parsed.protocol = "ssh";
-      parsed.resource = matched[2];
-      parsed.host = matched[2];
-      parsed.user = matched[1];
-      parsed.pathname = `/${matched[3]}`
-      parsed.parse_failed = false;
-    } else {
-      throwErr("URL parsing failed.");
+    if (typeof url !== "string" || !url.trim()) {
+        throwErr("Invalid url.")
     }
-  }
 
-  return parsed;
-};
+    if (url.length > parseUrl.MAX_INPUT_LENGTH) {
+        throwErr("Input exceeds maximum length. If needed, change the value of parseUrl.MAX_INPUT_LENGTH.")
+    }
+
+    if (normalize) {
+        if (typeof normalize !== "object") {
+            normalize = {
+                stripHash: false
+            }
+        }
+        url = normalizeUrl(url, normalize)
+    }
+
+    const parsed = parsePath(url)
+
+    // Potential git-ssh urls
+    if (parsed.parse_failed) {
+        const matched = parsed.href.match(GIT_RE)
+
+        if (matched) {
+            parsed.protocols = ["ssh"]
+            parsed.protocol = "ssh"
+            parsed.resource = matched[2]
+            parsed.host = matched[2]
+            parsed.user = matched[1]
+            parsed.pathname = `/${matched[3]}`
+            parsed.parse_failed = false
+        } else {
+            throwErr("URL parsing failed.")
+        }
+    }
+
+    return parsed;
+}
 
 parseUrl.MAX_INPUT_LENGTH = 2048
 

--- a/test/index.mjs
+++ b/test/index.mjs
@@ -289,18 +289,6 @@ const INPUTS = [
   ],
 ];
 
-
-
-
-
-// test('SSH URL with URL-encoded spaces', 'git@ssh.dev.azure.com:v3/ORG/My%20project/repo');
-// test('SSH URL with non URL-encoded spaces', 'git@ssh.dev.azure.com:v3/ORG/My project/repo');
-// test('SSH URL without spaces', 'git@ssh.dev.azure.com:v3/ORG/My-project/repo');
-// test('HTTPS URL with URL-encoded spaces', 'https://ORG@dev.azure.com/ORG/My%20project/_git/repo');
-// test('HTTPS URL with non URL-encoded spaces', 'https://ORG@dev.azure.com/ORG/My project/_git/repo');
-// test('HTTPS URL without spaces', 'https://ORG@dev.azure.com/ORG/My-project/_git/repo');
-
-
 tester.describe("check urls", test => {
     INPUTS.forEach(function (c) {
         let url = Array.isArray(c[0]) ? c[0][0] : c[0]

--- a/test/index.mjs
+++ b/test/index.mjs
@@ -1,7 +1,8 @@
 // Dependencies
+
+import normalizeUrl from "normalize-url";
 import parseUrl from "../dist/index.js";
 import tester from "tester";
-import normalizeUrl from "normalize-url";
 
 const INPUTS = [
     [
@@ -165,8 +166,140 @@ const INPUTS = [
         , query: {}
         , parse_failed: false
       }
-  ]
+  ],
+  [
+    [
+      "git@ssh.dev.azure.com:v3/ORG/My-Project/repo",
+      false,
+    ],
+    {
+      protocols: ["ssh"],
+      protocol: "ssh",
+      port: "",
+      resource: "ssh.dev.azure.com",
+      host: "ssh.dev.azure.com",
+      user: "git",
+      password: "",
+      pathname: "/v3/ORG/My-Project/repo",
+      hash: "",
+      search: "",
+      query: {},
+      parse_failed: false,
+    },
+  ],
+  [
+    [
+      "git@ssh.dev.azure.com:v3/ORG/My%20Project/repo",
+      false,
+    ],
+    {
+      protocols: ["ssh"],
+      protocol: "ssh",
+      port: "",
+      resource: "ssh.dev.azure.com",
+      host: "ssh.dev.azure.com",
+      user: "git",
+      password: "",
+      pathname: "/v3/ORG/My%20Project/repo",
+      hash: "",
+      search: "",
+      query: {},
+      parse_failed: false,
+    },
+  ],
+  [
+    [
+      "git@ssh.dev.azure.com:v3/ORG/My Project/repo",
+      false,
+    ],
+    {
+      protocols: ["ssh"],
+      protocol: "ssh",
+      port: "",
+      resource: "ssh.dev.azure.com",
+      host: "ssh.dev.azure.com",
+      user: "git",
+      password: "",
+      pathname: "/v3/ORG/My Project/repo",
+      hash: "",
+      search: "",
+      query: {},
+      parse_failed: false,
+    },
+  ],
+  [
+    [
+      "git@ssh.dev.azure.com:v3/ORG/My-Project/repo",
+      false,
+    ],
+    {
+      protocols: ["ssh"],
+      protocol: "ssh",
+      port: "",
+      resource: "ssh.dev.azure.com",
+      host: "ssh.dev.azure.com",
+      user: "git",
+      password: "",
+      pathname: "/v3/ORG/My-Project/repo",
+      hash: "",
+      search: "",
+      query: {},
+      parse_failed: false,
+    },
+  ],
+  [
+    [
+      "https://ORG@dev.azure.com/ORG/My%20Project/_git/repo",
+      false,
+    ],
+    {
+      protocols: ["https"],
+      protocol: "https",
+      port: "",
+      resource: "dev.azure.com",
+      host: "dev.azure.com",
+      user: "ORG",
+      password: "",
+      pathname: "/ORG/My%20Project/_git/repo",
+      hash: "",
+      search: "",
+      query: {},
+      parse_failed: false,
+    },
+  ],
+  [
+    [
+      "https://ORG@dev.azure.com/ORG/My-Project/_git/repo",
+      false,
+    ],
+    {
+      protocols: ["https"],
+      protocol: "https",
+      port: "",
+      resource: "dev.azure.com",
+      host: "dev.azure.com",
+      user: "ORG",
+      password: "",
+      pathname: "/ORG/My-Project/_git/repo",
+      hash: "",
+      search: "",
+      query: {},
+      parse_failed: false,
+    },
+  ],
 ];
+
+
+
+
+
+// test('SSH URL with URL-encoded spaces', 'git@ssh.dev.azure.com:v3/ORG/My%20project/repo');
+// test('SSH URL with non URL-encoded spaces', 'git@ssh.dev.azure.com:v3/ORG/My project/repo');
+// test('SSH URL without spaces', 'git@ssh.dev.azure.com:v3/ORG/My-project/repo');
+// test('HTTPS URL with URL-encoded spaces', 'https://ORG@dev.azure.com/ORG/My%20project/_git/repo');
+// test('HTTPS URL with non URL-encoded spaces', 'https://ORG@dev.azure.com/ORG/My project/_git/repo');
+// test('HTTPS URL without spaces', 'https://ORG@dev.azure.com/ORG/My-project/_git/repo');
+
 
 tester.describe("check urls", test => {
     INPUTS.forEach(function (c) {


### PR DESCRIPTION
fixes #https://github.com/IonicaBizau/git-url-parse/issues/162


Edit - I made a silly mistake. I didn't realize https://github.com/IonicaBizau/parse-url/pull/72 was already opened when I ran off and did this. I am handling one extra thing non encoded whitespace in this change. Open to suggestions on how to handle

I am trying to use `git-parse-url` and noticing it is failing for Azure DevOps (visual studio) ssh urls where there is a space in the project/repo names. 

I traced the bug back to this part of the logic 

```ts

  const parsed = parsePath(url)

// Potential git-ssh urls
    if (parsed.parse_failed) {

       // Here the ADO SSH Urls with spaces were not matching the GIT_RE, causing it to throw
        const matched = parsed.href.match(GIT_RE) 

        if (matched) {
            parsed.protocols = ["ssh"]
            parsed.protocol = "ssh"
            parsed.resource = matched[2]
            parsed.host = matched[2]
            parsed.user = matched[1]
            parsed.pathname = `/${matched[3]}`
            parsed.parse_failed = false
        } else {
            throwErr("URL parsing failed.")
        }
    }
```

In this PR I updated the REGEX to allow match on whitespace characters + encoding characters within the path section
` const GIT_RE = /^(?:([a-z_][a-z0-9_-]{0,31})@|https?:\/\/)([\w\.\-@]+)[\/:](([\~,\.\w,\-,\_,\/,\s]|%[0-9A-Fa-f]{2})+?(?:\.git|\/)?)$/;`

The part that changed was the path capture group: 
 `(([\~,\.\w,\-,\_,\/,\s]|%[0-9A-Fa-f]{2})+?(?:\.git|\/)?)` 
- `\s` was added to the character list to support white spaces
- `|%[0-9A-Fa-f]{2}` to support encodings

## Changes
- Added unit tests to verify it works and doesn't break anything else
- The build was also breaking for me and I noticed the same was true in github actions, I modified package json which seems to fix it, but pkgroll is a new lib for me so a second pair of eyes on that would be a good thing