### PR TITLE
fix: Publish missing types declaration file

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "cli.js",
     "index.js",
     "index.d.ts",
+    "index.d.mts",
     "bloggify.js",
     "bloggify.json",
     "bloggify/"


### PR DESCRIPTION
Hi,

when using `parse-url` with a ESModule project, TypeScript cannot build the project, displaying the following error:

```
Could not find a declaration file for module 'parse-url'. '[...]/node_modules/parse-url/dist/index.mjs' implicitly has an 'any' type.
  There are types at '[...]/node_modules/parse-url/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'parse-url' library may need to update its package.json or typings.ts(7016)
```

This PR fixes the error by telling npm to publish the missing `index.d.mts` file.