### PR TITLE
feat: handle hash fragments in SSH URLs

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -195,7 +195,7 @@ function normalizeUrl(urlString, options) {
   return urlString;
 }
 
-/**
+/*!
  * parseUrl
  * Parses the input url.
  *
@@ -248,7 +248,14 @@ const parseUrl = (url, normalize = false) => {
   }
   const parsed = parsePath(url);
   if (parsed.parse_failed) {
-    const matched = parsed.href.match(GIT_RE);
+    let hash = "";
+    let hrefWithoutHash = parsed.href;
+    const hashIndex = parsed.href.indexOf("#");
+    if (hashIndex !== -1) {
+      hash = parsed.href.slice(hashIndex + 1);
+      hrefWithoutHash = parsed.href.slice(0, hashIndex);
+    }
+    const matched = hrefWithoutHash.match(GIT_RE);
     if (matched) {
       parsed.protocols = ["ssh"];
       parsed.protocol = "ssh";
@@ -257,6 +264,10 @@ const parseUrl = (url, normalize = false) => {
       parsed.user = matched[1];
       parsed.pathname = `/${matched[3]}`;
       parsed.parse_failed = false;
+      parsed.hash = hash;
+      if (hash) {
+        parsed.href = `${hrefWithoutHash}#${hash}`;
+      }
     } else {
       throwErr("URL parsing failed.");
     }

--- a/dist/index.js
+++ b/dist/index.js
@@ -195,7 +195,7 @@ function normalizeUrl(urlString, options) {
   return urlString;
 }
 
-/*!
+/**
  * parseUrl
  * Parses the input url.
  *

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -246,7 +246,14 @@ const parseUrl = (url, normalize = false) => {
   }
   const parsed = parsePath(url);
   if (parsed.parse_failed) {
-    const matched = parsed.href.match(GIT_RE);
+    let hash = "";
+    let hrefWithoutHash = parsed.href;
+    const hashIndex = parsed.href.indexOf("#");
+    if (hashIndex !== -1) {
+      hash = parsed.href.slice(hashIndex + 1);
+      hrefWithoutHash = parsed.href.slice(0, hashIndex);
+    }
+    const matched = hrefWithoutHash.match(GIT_RE);
     if (matched) {
       parsed.protocols = ["ssh"];
       parsed.protocol = "ssh";
@@ -255,6 +262,10 @@ const parseUrl = (url, normalize = false) => {
       parsed.user = matched[1];
       parsed.pathname = `/${matched[3]}`;
       parsed.parse_failed = false;
+      parsed.hash = hash;
+      if (hash) {
+        parsed.href = `${hrefWithoutHash}#${hash}`;
+      }
     } else {
       throwErr("URL parsing failed.");
     }

--- a/src/index.js
+++ b/src/index.js
@@ -70,7 +70,16 @@ const parseUrl = (url, normalize = false) => {
 
     // Potential git-ssh urls
     if (parsed.parse_failed) {
-        const matched = parsed.href.match(GIT_RE)
+        // Extract hash fragment before matching, as GIT_RE doesn't handle it
+        let hash = ""
+        let hrefWithoutHash = parsed.href
+        const hashIndex = parsed.href.indexOf("#")
+        if (hashIndex !== -1) {
+            hash = parsed.href.slice(hashIndex + 1)
+            hrefWithoutHash = parsed.href.slice(0, hashIndex)
+        }
+
+        const matched = hrefWithoutHash.match(GIT_RE)
 
         if (matched) {
             parsed.protocols = ["ssh"]
@@ -80,6 +89,10 @@ const parseUrl = (url, normalize = false) => {
             parsed.user = matched[1]
             parsed.pathname = `/${matched[3]}`
             parsed.parse_failed = false
+            parsed.hash = hash
+            if (hash) {
+                parsed.href = `${hrefWithoutHash}#${hash}`
+            }
         } else {
             throwErr("URL parsing failed.")
         }

--- a/test/index.mjs
+++ b/test/index.mjs
@@ -307,6 +307,67 @@ const INPUTS = [
       parse_failed: false,
     },
   ],
+  // SSH URLs with hash fragments
+  [
+    [
+      "git@github.com:IonicaBizau/git-stats.git#v1.0.0",
+      false,
+    ],
+    {
+      protocols: ["ssh"],
+      protocol: "ssh",
+      port: "",
+      resource: "github.com",
+      host: "github.com",
+      user: "git",
+      password: "",
+      pathname: "/IonicaBizau/git-stats.git",
+      hash: "v1.0.0",
+      search: "",
+      query: {},
+      parse_failed: false,
+    },
+  ],
+  [
+    [
+      "git@github.com:owner/repo.git#feature/branch",
+      false,
+    ],
+    {
+      protocols: ["ssh"],
+      protocol: "ssh",
+      port: "",
+      resource: "github.com",
+      host: "github.com",
+      user: "git",
+      password: "",
+      pathname: "/owner/repo.git",
+      hash: "feature/branch",
+      search: "",
+      query: {},
+      parse_failed: false,
+    },
+  ],
+  [
+    [
+      "git@github.com:owner/repo#semver:^1.0.0",
+      false,
+    ],
+    {
+      protocols: ["ssh"],
+      protocol: "ssh",
+      port: "",
+      resource: "github.com",
+      host: "github.com",
+      user: "git",
+      password: "",
+      pathname: "/owner/repo",
+      hash: "semver:^1.0.0",
+      search: "",
+      query: {},
+      parse_failed: false,
+    },
+  ],
 ];
 
 tester.describe("check urls", test => {


### PR DESCRIPTION
Fixes #99 

When parsing SSH URLs like `git@github.com:owner/repo.git#v1.0.0`,
the hash fragment was causing parsing to fail because the GIT_RE
regex doesn't account for hash fragments.

This fix extracts the hash fragment before regex matching and
restores it on the parsed result, allowing SSH URLs with hash
fragments (commonly used for npm/yarn git dependencies with
semver specifiers) to be parsed correctly.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
